### PR TITLE
fix: 修复在arch下的编译错误

### DIFF
--- a/rmdb_client/main.cpp
+++ b/rmdb_client/main.cpp
@@ -1,5 +1,6 @@
 #include <netdb.h>
 #include <netinet/in.h>
+#include <cstdio>
 #include <readline/history.h>
 #include <readline/readline.h>
 #include <sys/socket.h>

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -10,6 +10,7 @@ See the Mulan PSL v2 for more details. */
 
 #pragma once
 
+#include <string>
 #include <atomic>
 #include <chrono>
 #include <cstdint>

--- a/src/rmdb.cpp
+++ b/src/rmdb.cpp
@@ -8,6 +8,7 @@ EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
 MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
 See the Mulan PSL v2 for more details. */
 
+#include <cstdio>
 #include <netinet/in.h>
 #include <readline/history.h>
 #include <readline/readline.h>


### PR DESCRIPTION
## Summary by Sourcery

Fix compilation errors on Arch Linux by adding missing standard library includes in source files.

Bug Fixes:
- Add missing <cstdio> includes to rmdb_client/main.cpp and src/rmdb.cpp to resolve undefined I/O functions.
- Add missing <string> include to src/common/config.h to resolve undefined std::string.