### PR TITLE
fix(record):rm_manager的每页记录条数计算错误

### DIFF
--- a/src/record/rm_manager.h
+++ b/src/record/rm_manager.h
@@ -45,7 +45,7 @@ class RmManager {
         file_hdr.first_free_page_no = RM_NO_PAGE;
         // We have: sizeof(hdr) + (n + 7) / 8 + n * record_size <= PAGE_SIZE
         file_hdr.num_records_per_page =
-            (BITMAP_WIDTH * (PAGE_SIZE - 1 - (int)sizeof(RmFileHdr)) + 1) / (1 + record_size * BITMAP_WIDTH);
+            (BITMAP_WIDTH * (PAGE_SIZE - 1 - (int)sizeof(RmPageHdr)) + 1) / (1 + record_size * BITMAP_WIDTH);
         file_hdr.bitmap_size = (file_hdr.num_records_per_page + BITMAP_WIDTH - 1) / BITMAP_WIDTH;
 
         // 将file header写入磁盘文件（名为file name，文件描述符为fd）中的第0页


### PR DESCRIPTION
这里记录的是每页能放的记录条数，每页前面放到的是page头，这里写成file头，会导致bitmap空间比实际的要大

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复：
- 修正了 `num_records_per_page` 的计算公式，将减去 `sizeof(RmPageHdr)` 而不是 `sizeof(RmFileHdr)`，以防止过大的位图分配。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the num_records_per_page formula by subtracting sizeof(RmPageHdr) rather than sizeof(RmFileHdr) to prevent oversized bitmap allocation.

</details>